### PR TITLE
Declare `geru` package as a namespace package

### DIFF
--- a/geru/__init__.py
+++ b/geru/__init__.py
@@ -1,0 +1,1 @@
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)


### PR DESCRIPTION
Avoid import errors when installed with other packages in the `geru` namespace.